### PR TITLE
Prevent Python missing package import errors

### DIFF
--- a/.github/linters/.pylintrc
+++ b/.github/linters/.pylintrc
@@ -1,0 +1,3 @@
+[MAIN]
+disable=
+    import-error

--- a/.github/linters/pyrightconfig.json
+++ b/.github/linters/pyrightconfig.json
@@ -1,0 +1,3 @@
+{
+    "reportMissingImports": "information"
+}


### PR DESCRIPTION
## Pull Request Details

What?

Enables the Pyright type checker and configures Pyright and Pylint so that missing package imports inside Megalinter don't cause errors. Disables the pre-listing installation of Python packages.

## Why?

Some Python packages such as skl2onnx fail to install inside the megalinter container, causing all linters to fail.
We don't need megalinter to test whether requirements can be installed correctly as our testing workflow (ci_cd_workflow.yml) will do this In a fresh environment.
If we disable installation of packages inside the megalinter container and reconfigure the Pyright and Pylint linters to ignore missing packages, we can benefit from these two linters.
This also has the benefit of much faster megalinter checks (because the installation took up to 15 minutes on Github).

## How?

adds config files for pyright and pylint inside .github/linters

## Testing?

Tested as part of https://github.com/HealthDataInsight/indoor_positioning/pull/16