### PR TITLE
Fix markdown link checkers

### DIFF
--- a/.github/linters/.markdown-link-check.json
+++ b/.github/linters/.markdown-link-check.json
@@ -5,6 +5,12 @@
         },
         {
             "pattern": "^adr-template.md"
+        },
+        {
+            "pattern": "^https://healthdatainsight.sharepoint.com"
+        },
+        {
+            "pattern": "^https://img.shields.io"
         }
     ],
     "retryOn429": true,

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,0 +1,5 @@
+# Exclude URLs and mail addresses from checking (supports regex).
+exclude = [
+    '^https://megalinter\.io', 
+    '^https://healthdatainsight\.sharepoint\.com'
+]


### PR DESCRIPTION
# Pull Request Details

## What?

Sets the link checkers markdown-link-checker and lychee to ignore the domains `healthdatainsight.sharepoint.com`, `megalinter.io`, and `https://img.shields.io`

## Why?

Stale link linting is useful for maintaining the integrity of documentation, but these flag here because the domains don't respond in the expected way (e.g. our Sharepoint is not accessible to the link checker). 

## How?

Adds config files for each linter, one in .github/linters and the other in the root directory. 

## Testing?

this was tested on https://github.com/HealthDataInsight/indoor_positioning/pull/15

## Anything Else?

I tried to put lychee.toml in .github/linters (using the megalinter arguments) but megalinter didn't recognize the config file for lychee.toml when placed anywhere but the root of the repo. If we can work out how to move it it would be nicer.
