### PR TITLE
pin action versions by SHA

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        # Pin to version 1.237.0
+        uses: ruby/setup-ruby@eaecf785f6a34567a6d97f686bbb7bccc1ac1e5c
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true

--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -42,7 +42,8 @@ jobs:
         id: ml
         # You can override MegaLinter flavor used to have faster performances
         # More info at https://megalinter.io/flavors/
-        uses: oxsecurity/megalinter@v8
+        # Pin to https://github.com/oxsecurity/megalinter/releases/tag/v8.6.0
+        uses: oxsecurity/megalinter@04cf22b980c2e9c2121553417ed651c944afc8e1
         env:
           # All available variables are described in documentation
           # https://megalinter.io/configuration/

--- a/lib/way_of_working/code_linting/hdi/templates/.github/workflows/mega-linter.yml
+++ b/lib/way_of_working/code_linting/hdi/templates/.github/workflows/mega-linter.yml
@@ -42,7 +42,8 @@ jobs:
         id: ml
         # You can override MegaLinter flavor used to have faster performances
         # More info at https://megalinter.io/flavors/
-        uses: oxsecurity/megalinter@v8
+        # Pin to https://github.com/oxsecurity/megalinter/releases/tag/v8.6.0
+        uses: oxsecurity/megalinter@04cf22b980c2e9c2121553417ed651c944afc8e1
         env:
           # All available variables are described in documentation
           # https://megalinter.io/configuration/


### PR DESCRIPTION
# Pull Request Details

## What?

Pins the external GitHub action we use (megalinter) to a specific commit using SHA.

## Why?

Currently we specify the major release of the action to be used. This is flagged by KICS as a security issue because the release does not point to a specific commit and hence could be overwritten to allow an action to insert arbitrary code into a repo. see https://docs.kics.io/latest/queries/cicd-queries/555ab8f9-2001-455e-a077-f2d0f41e2fb9/

Fixing this will also clear up our megalinter errors and help us to spot other issues with our code.

## How?

Adds a specific commit SHA (from v8.6.0 of megalinter) to the Github workflow so these releases will be used

## Testing?

KICS errors no longer appear in megalinter (see https://github.com/HealthDataInsight/indoor_positioning/pull/49)